### PR TITLE
Make the commit hash a link to github.

### DIFF
--- a/generator/templates/generator/options.html
+++ b/generator/templates/generator/options.html
@@ -11,7 +11,7 @@
       <h1>Chrono Trigger Jets of Time Randomizer</h1>
       <h4>Based on beta version 3.2.0</h4>
       <h5 class="pl-3">Last update: {{ version.date }}</h5>
-      <h5 class="pl-3">Commit hash: {{ version.hash }}</h5>
+      <h5 class="pl-3">Commit hash: <a href="https://github.com/Anskiy/jetsoftime/tree/{{ version.hash }}" target="_blank">{{ version.hash }}</a></h5>
 
       <!-- Preset buttons -->
       <h2 class="pt-4">Presets</h2>


### PR DESCRIPTION
Tiny change mostly because I like being able to go look at the history easily.

This will work even if the commit's not in that particular github repo, so long as it's on github generally. That or we can change it to Pseudoarc/jetsoftime.