### PR TITLE
write_spoiler_log accepts a file-like object now, so use it directly

### DIFF
--- a/generator/randomizerinterface.py
+++ b/generator/randomizerinterface.py
@@ -363,19 +363,9 @@ class RandomizerInterface:
         spoiler_log = io.StringIO()
         rando = randomizer.Randomizer(cls.get_base_rom(), is_vanilla=True, settings=settings, config=config)
 
-        # The Randomizer.write_spoiler_log method writes directly to a file, so
-        # recreate it here using the helper functions and pass them a StringIO
-        # object instead of a file.
-        rando.write_settings_spoilers(spoiler_log)
-        rando.write_tab_spoilers(spoiler_log)
-        rando.write_key_item_spoilers(spoiler_log)
-        rando.write_boss_rando_spoilers(spoiler_log)
-        rando.write_character_spoilers(spoiler_log)
-        rando.write_boss_stat_spoilers(spoiler_log)
-        rando.write_treasure_spoilers(spoiler_log)
-        rando.write_drop_charm_spoilers(spoiler_log)
-        rando.write_shop_spoilers(spoiler_log)
-        rando.write_item_stat_spoilers(spoiler_log)
+        # The Randomizer.write_spoiler_log method writes directly to a file,
+        # but it works if we pass a StringIO instead.
+        rando.write_spoiler_log(spoiler_log)
 
         return spoiler_log
 


### PR DESCRIPTION
I changed it to do this in my JSON spoiler logs PR, see https://github.com/Pseudoarc/jetsoftime/blob/61598b3ec6013b9304ed99c18f1776abfdae764c/sourcefiles/randomizer.py#L800-L815

Changing this should mean the spoilers always exactly match the underlying generator without this project having to do anything explicit to keep up.