### PR TITLE
Add opengraph share previews for seed share pages

### DIFF
--- a/generator/templates/generator/base.html
+++ b/generator/templates/generator/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html prefix="og: https://ogp.me/ns#">
   <head>
     <title>{% block title %}Chrono Trigger: Jets of Time Randomizer{% endblock %}</title>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>

--- a/generator/templates/generator/seed.html
+++ b/generator/templates/generator/seed.html
@@ -1,9 +1,18 @@
 {% extends 'generator/base.html' %}
 
+{% block title %}Seed {{ share_id }} - {{ block.super }}{% endblock %}
+
 {% block imports %}
     {% load static %}
     <script src="{% static 'generator/seed.js' %}"></script>
     <link rel="stylesheet" href="{% static 'generator/background_select.css' %}">
+    {% if is_permalink %}
+        <meta property="og:title" content="Seed {{ share_id }} - Chrono Trigger: Jets of Time Randomizer" />
+        <meta property="og:description" content="{{ share_info }}" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://beta.ctjot.com{% url 'generator:share' share_id %}" />
+        <meta property="og:image" content="https://beta.ctjot.com{% url 'generator:seedimg' share_id %}" />
+    {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/generator/templates/generator/seed.html
+++ b/generator/templates/generator/seed.html
@@ -10,8 +10,8 @@
         <meta property="og:title" content="Seed {{ share_id }} - Chrono Trigger: Jets of Time Randomizer" />
         <meta property="og:description" content="{{ share_info }}" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://beta.ctjot.com{% url 'generator:share' share_id %}" />
-        <meta property="og:image" content="https://beta.ctjot.com{% url 'generator:seedimg' share_id %}" />
+	<meta property="og:url" content="{{ base_uri }}{% url 'generator:share' share_id %}" />
+	<meta property="og:image" content="{{ base_uri }}{% url 'generator:seedimg' share_id %}" />
     {% endif %}
 {% endblock %}
 

--- a/generator/urls.py
+++ b/generator/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path('generate-rom/', views.GenerateView.as_view(), name='generate'),
     path('share/<str:share_id>/', views.ShareLinkView.as_view(), name='share'),
     path('practice/<str:share_id>/', views.PracticeSeedView.as_view(), name='practice'),
+    path('seedimg/<str:share_id>.png', views.SeedImageView.as_view(), name='seedimg'),
     path('seed/', views.DownloadSeedView.as_view(), name='seed'),
     path('spoiler_log/<str:share_id>/', views.DownloadSpoilerLogView.as_view(), name='spoiler_log'),
 ]

--- a/generator/views.py
+++ b/generator/views.py
@@ -101,6 +101,7 @@ class ShareLinkView(View):
         rom_form = RomForm()
         context = {'share_id': game.share_id,
                    'is_permalink': True,
+                   'base_uri': request.build_absolute_uri(''),
                    'form': rom_form,
                    'spoiler_log': RandomizerInterface.get_web_spoiler_log(pickle.loads(game.configuration)),
                    'is_race_seed': game.race_seed,

--- a/generator/views.py
+++ b/generator/views.py
@@ -239,7 +239,7 @@ class SeedImageView(View):
             for y in range(0, 200, squaresize):
                 # Draw a square in a random color
                 d.polygon([(x,y),(x+squaresize,y),(x+squaresize,y+squaresize),(x,y+squaresize)],
-                        fill=(rgen.randint(0,255), rgen.randint(0,255), rgen.randint(0,255)))
+                        fill=(rgen.randint(0,31)*8, rgen.randint(0,31)*8, rgen.randint(0,31)*8))
 
         with io.BytesIO() as f:
             img.save(f, 'PNG')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Django==4.0.1
 nanoid==2.0.0
 sqlparse==0.4.2
 tzdata==2021.5
+Pillow==9.2.0


### PR DESCRIPTION
This is a little bit of an arguably silly thing, but it's to make it so when share links are put in places that support opengraph (which includes Discord, importantly), you'll get a nice-looking preview. The biggest part of the work is creating images to represent the share link. At first I played with having text but eventually decided it'd be nicer to just generate something abstract that just represents the share ID.

Here's some examples of what the images will look like (EDIT: I changed the colors so only colors that can appear on a SNES (i.e. 15-bit RGB) are used and these images used 24-bit color instead, but same idea and as it happens the random numbers end up as the closest 15-bit color anyway so they don't look very different):
![2Ek7POxnan2pLYX](https://user-images.githubusercontent.com/106004/197959135-b8888cf7-8b6d-4b1e-8c9c-d4188c77dfc1.png)
![g43Qg9yaFUIkvjt](https://user-images.githubusercontent.com/106004/197959138-3162cb9b-14d9-4617-89d5-728a3d663547.png)

And here's what a discord preview looks like (guess who was testing for script injection, lol):

![Screenshot from 2022-10-26 00-24-46](https://user-images.githubusercontent.com/106004/197961772-d4ba98aa-446e-4098-916a-9c92764cf1d3.png)

This does add another requirement, [Pillow](https://pillow.readthedocs.io/en/stable/), for the image manipulation. I don't think this should be an issue, since it's pretty well-supported and all that.