### PR TITLE
Add a JSON spoiler log fetching endpoint, and enable CORS for it

### DIFF
--- a/ctjot/settings.py
+++ b/ctjot/settings.py
@@ -37,10 +37,12 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     'generator',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -122,3 +124,7 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOW_METHODS = ["GET", "OPTIONS"]
+CORS_URLS_REGEX = r"^/spoiler_log/.*\.json$"

--- a/generator/randomizerinterface.py
+++ b/generator/randomizerinterface.py
@@ -448,6 +448,24 @@ class RandomizerInterface:
 
         return spoiler_log
 
+    @classmethod
+    def get_json_spoiler_log(cls, config: randoconfig.RandoConfig, settings: rset.Settings) -> io.StringIO:
+        """
+        Get a spoiler log file-like object.
+
+        :param config: RandoConfig object describing the seed
+        :param settings: RandoSettings object describing the seed
+        :return: File-like object with spoiler log data for the given seed data
+        """
+        spoiler_log = io.StringIO()
+        rando = randomizer.Randomizer(cls.get_base_rom(), is_vanilla=True, settings=settings, config=config)
+
+        # The Randomizer.write_spoiler_log method writes directly to a file,
+        # but it works if we pass a StringIO instead.
+        rando.write_json_spoiler_log(spoiler_log)
+
+        return spoiler_log
+
     @staticmethod
     def get_web_spoiler_log(config: randoconfig.RandoConfig) -> dict[str, list[dict[str, str]]]:
         """

--- a/generator/templates/generator/seed/spoiler_log_section.html
+++ b/generator/templates/generator/seed/spoiler_log_section.html
@@ -1,7 +1,7 @@
 
         <div class="pt-2">
           <input type="button" class="btn btn-primary" id="spoiler_log_button" value="Show Spoiler Log" data-toggle="collapse" data-target="#spoiler_section" aria-expanded="false" aria-controls="spoiler_section">
-          <button class="btn btn-primary" type="button" onclick="window.open('/spoiler_log/{{share_id}}')">Download Spoiler Log</button>
+	  <a class="btn btn-primary" href="{% url 'generator:spoiler_log' share_id %}" target="_blank">Download Spoiler Log</a>
         </div>
 
         <div class="tab-content collapse border border-primary rounded p-3" id="spoiler_section">

--- a/generator/urls.py
+++ b/generator/urls.py
@@ -13,5 +13,6 @@ urlpatterns = [
     path('share/<str:share_id>/', views.ShareLinkView.as_view(), name='share'),
     path('practice/<str:share_id>/', views.PracticeSeedView.as_view(), name='practice'),
     path('seed/', views.DownloadSeedView.as_view(), name='seed'),
-    path('spoiler_log/<str:share_id>/', views.DownloadSpoilerLogView.as_view(), name='spoiler_log'),
+    path('spoiler_log/<str:share_id>.txt', views.DownloadSpoilerLogView.as_view(), name='spoiler_log'),
+    path('spoiler_log/<str:share_id>.json', views.DownloadJSONSpoilerLogView.as_view(), name='json_spoiler_log'),
 ]

--- a/generator/views.py
+++ b/generator/views.py
@@ -191,6 +191,25 @@ class DownloadSpoilerLogView(View):
             return render(request, 'generator/error.html', {'error_text': 'No spoiler log available for this seed.'},
                           status=404)
 
+class DownloadJSONSpoilerLogView(View):
+    """
+    Create and send a JSON spoiler log to the user for the seed with the given share ID.
+    """
+    @classmethod
+    def get(cls, request, share_id):
+        try:
+            game = Game.objects.get(share_id=share_id)
+        except Game.DoesNotExist:
+            return render(request, 'generator/error.html', {'error_text': 'Seed does not exist.'}, status=404)
+
+        response = HttpResponse(content_type='application/json')
+        if not game.race_seed:
+            spoiler_log = RandomizerInterface.get_json_spoiler_log(
+                pickle.loads(game.configuration), pickle.loads(game.settings))
+            response.write(spoiler_log.getvalue())
+        else:
+            response.write(b'{"cheating": "not_allowed"}')
+        return response
 
 class PracticeSeedView(View):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ asgiref==3.5.0
 Django==4.0.1
 nanoid==2.0.0
 sqlparse==0.4.2
+django-cors-headers==3.13.0
 tzdata==2021.5


### PR DESCRIPTION
Adds another small dependency, `django-cors-headers`, which handles the CORS stuff.

This changes the existing spoiler log endpoint to be at `/spoiler_log/<str:share_id>.txt` and adds `/spoiler_log/<str:share_id>.json`. The latter doesn't set content-disposition and such, and does add CORS headers so it could in theory be used by another webpage if someone wanted to make something that dynamically rendered something based on a spoiler or anything like that.

Unrelated but I also changed the "Download Spoiler Log" button to a link instead of a button with an `onclick` that opened a background window because then it shows the URL it's opening on hover (and my understanding is it's better for screen readers this way).