### PR TITLE
Make generated seeds redirect right to share page; add a link to create practice seeds

### DIFF
--- a/generator/templates/generator/seed.html
+++ b/generator/templates/generator/seed.html
@@ -10,7 +10,7 @@
     <div class="container">
       <div class="pt-2 pb-2">
         <h1>Download Seed</h1>
-        <h3 class="pb-2"><a target="_blank" href="{% url 'generator:share' share_id %}">Seed share link</a></h3>
+	<h3 class="pb-2"><a id="seed_share" target="_blank" href="{% url 'generator:share' share_id %}">Seed share link</a> &middot;&middot;&middot; <a id="seed_practice" target="_blank" href="{% url 'generator:practice' share_id %}">(create practice seed)</a></h3>
         <pre>
 {{ share_info }}
         </pre>

--- a/generator/views.py
+++ b/generator/views.py
@@ -1,6 +1,6 @@
 # Django libraries
 from django.http import HttpResponse
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from wsgiref.util import FileWrapper
 
 # Site libraries
@@ -71,7 +71,7 @@ class GenerateView(FormView):
                    'spoiler_log': RandomizerInterface.get_web_spoiler_log(pickle.loads(game.configuration)),
                    'is_race_seed': game.race_seed,
                    'share_info': share_info.getvalue()}
-        return render(self.request, 'generator/seed.html', context)
+        return redirect('/share/' + game.share_id)
 
     def form_invalid(self, form):
         # TODO: Replace this error handling with something better eventually.
@@ -214,7 +214,7 @@ class PracticeSeedView(View):
                    'is_race_seed': game.race_seed,
                    'share_info': share_info.getvalue()}
 
-        return render(request, 'generator/seed.html', context)
+        return redirect('/share/' + game.share_id)
 
 
 def get_share_id() -> str:


### PR DESCRIPTION
okay, one more PR in me apparently

This will make it so you just always get directly sent to a `/share/whatever` page when creating a seed or a practice seed. I think this is probably clearer (especially for practice seeds -- it's sorta weird for the URL bar to still say `/practice/whatever` despite it being several different seeds) and makes it easier to copy-paste from the URL bar if people want to.

I also thought I'd add a practice seed link to the share page, so it's easier to figure out that feature exists.