### PR TITLE
Use a different way of building the base URI that seems to work

### DIFF
--- a/generator/views.py
+++ b/generator/views.py
@@ -92,7 +92,7 @@ class ShareLinkView(View):
         rom_form = RomForm()
         context = {'share_id': game.share_id,
                    'is_permalink': True,
-                   'base_uri': request.build_absolute_uri(''),
+                   'base_uri': request.build_absolute_uri('/')[:-1],
                    'form': rom_form,
                    'spoiler_log': RandomizerInterface.get_web_spoiler_log(pickle.loads(game.configuration)),
                    'is_race_seed': game.race_seed,


### PR DESCRIPTION
I tested this with the new container deploy with `-s`. I think the issue might have been with the proxy setup that made it generate URLs like `https://ctjot.com/share/hKEbs4UR62MMnbL//seedimg/hKEbs4UR62MMnbL.png` (rather than `https://ctjot.com/seedimg/hKEbs4UR62MMnbL.png` as needed). This also still works with the dev deploy, not that it should matter really.

Anyway the main outcome of this is that those seed images I worked to make should work again, assuming it produces correct URLs as I think it should.