### PR TITLE
Add support for Rocksanity to beta.

### DIFF
--- a/generator/forms.py
+++ b/generator/forms.py
@@ -106,6 +106,7 @@ class GenerateForm(forms.Form):
     restore_johnny_race = forms.BooleanField(required=False)
     add_racelog_spot = forms.BooleanField(required=False)
     split_arris_dome = forms.BooleanField(required=False)
+    rocksanity = forms.BooleanField(required=False)
     vanilla_robo_ribbon = forms.BooleanField(required=False)
     vanilla_desert = forms.BooleanField(required=False)
 

--- a/generator/randomizerinterface.py
+++ b/generator/randomizerinterface.py
@@ -320,6 +320,7 @@ class RandomizerInterface:
             'tackle_effects': GF.TACKLE_EFFECTS_ON,
             'starters_sufficient': GF.STARTERS_SUFFICIENT,
             'bucket_list': GF.BUCKET_LIST,
+            'rocksanity': GF.ROCKSANITY,
             # QoL
             'sightscope_always_on': GF.VISIBLE_HEALTH,
             'boss_sightscope': GF.BOSS_SIGHTSCOPE,

--- a/generator/static/generator/options.js
+++ b/generator/static/generator/options.js
@@ -71,6 +71,7 @@ function resetAll() {
   $('#id_starters_sufficient').prop('checked', false).change();
 
   $('#id_bucket_list').prop('checked', false).change();
+  $('#id_rocksanity').prop('checked', false).change();
 
   // Mystery Seed options
   // game modes

--- a/generator/templates/generator/options/extra_tab.html
+++ b/generator/templates/generator/options/extra_tab.html
@@ -71,6 +71,10 @@
                     <input type="checkbox" name="{{form.vanilla_desert.name}}" id="{{form.vanilla_desert.id_for_label}}"  data-toggle="toggle">
                     <label for="{{form.vanilla_desert.id_for_label}}">Vanilla Desert</label>
 		  </div>
+		  <div class="form-group form-check pl-0">
+                    <input type="checkbox" name="{{form.rocksanity.name}}" id="{{form.rocksanity.id_for_label}}"  data-toggle="toggle">
+                    <label for="{{form.rocksanity.id_for_label}}">Rocksanity</label>
+		  </div>
 		</div>
 	      </div>
             </div>


### PR DESCRIPTION
Adds support for Rocksanity as introduced in https://github.com/Pseudoarc/jetsoftime/pull/16

## Updates

* Adds Rocksanity flag under Extra tab.
* Updates `jetsoftime` submodule for Rocksanity update: https://github.com/Pseudoarc/jetsoftime/commit/52cd5ee9c9ee1c52785af74788d87ff1b69a49f4

## Testing

Loaded up with `./deploy/deploy.sh -d`.

1. Select "Rocksanity" on "Extra" tab.
2. Generate Seed.
3. Observe that "ROCKSANITY" and "UNLOCKED_SKYGATES" are included in the Flags
4. View Spoiler Log and observe that Key Items include rocks and rock locations
5. Download seed

[rocksanity-demo.webm](https://github.com/Anguirel86/ctjot_web_generator/assets/3493534/3a65736f-459f-48c4-89fb-eae95612633b)

Per spoiler, Lazy Carpenter indeed leads to Black Rock :smile: 

![lazy-carpenter-black-rock](https://github.com/Anguirel86/ctjot_web_generator/assets/3493534/731d9dd1-1edd-405e-a394-1dc8db36ebe6)
