### PR TITLE
Save cosmetics options to opt-in cookie for re-use between seeds

### DIFF
--- a/generator/static/generator/seed.js
+++ b/generator/static/generator/seed.js
@@ -17,18 +17,114 @@ $(document).on('hide.bs.collapse', '#cosmetic_section', function(e) {
 });
 
 /*
+ * Get cosmetic options from json-script data.
+ */
+function getCosmeticOptions() {
+  return JSON.parse(document.getElementById('cosmetics-options').textContent);
+}
+
+/*
  * Update the game options section of the seed page.
  */
 function updateGameOptions() {
+  let options = getCosmeticOptions();
 
   // Update the slider text boxes
-  var id_list = ['battle_speed', 'battle_message_speed', 'battle_gauge_style', 'background_selection']
-  for (const id of id_list) {
-    document.getElementById(id + "_text").value = document.getElementById("id_" + id).value
-  }
+  Object.entries(options).forEach(([id, option]) => {
+    if (option.type == 'slider') {
+      document.getElementById(id + "_text").value = document.getElementById("id_" + id).value;
+    }
+  });
 
   // Display the chosen background type.
   var selection = document.getElementById('id_background_selection').value;
   preview = document.getElementById('background_selection_preview');
   preview.className = 'menuBackground' + selection;
+}
+
+/*
+ * Load cosmetic options from cookie.
+ */
+function loadCosmeticOptionsCookie() {
+  // load cookie
+  let cookie = Cookies.get('ctjot_cosmetics');
+  if (!cookie) { return; }
+
+  try {
+    var cosmetics = JSON.parse(atob(cookie));
+  } catch (e) {
+    console.warn('Failed to parse ctjot_cosmetics cookie.', {name: e.name, message: e.message});
+  }
+  if (!cosmetics) { return; }
+
+  // update items from cookie
+  let options = getCosmeticOptions();
+  Object.entries(options).forEach(([id, option]) => {
+    let elem = document.getElementById("id_" + id);
+    if (elem) {
+      if (option.type == 'checked') {
+        let checked = cosmetics[id];
+        if (checked) { $('#id_' + id).bootstrapToggle('on'); }
+        else { $('#id_' + id).bootstrapToggle('off'); }
+      } else {
+        elem.value = cosmetics[id];
+      }
+    } else {
+      console.warn('Undefined cosmetics element.', {id: id});
+    }
+  });
+
+  updateGameOptions();
+}
+
+/*
+ * Save cosmetic options to cookie.
+ */
+function saveCosmeticOptionsCookie() {
+  var cosmetics = {};
+  let options = getCosmeticOptions();
+
+  // read form values into object
+  Object.entries(options).forEach(([id, option]) => {
+    if (option.type == 'checked') {
+      let checked = $('#id_' + id).is(':checked');
+      cosmetics[id] = (checked) ? true : false;
+    } else {
+      cosmetics[id] = document.getElementById("id_" + id).value;
+    }
+  });
+
+  // stringify and base64 encode JSON then write cookie
+  try {
+    let cookie = btoa(JSON.stringify(cosmetics));
+    Cookies.set('ctjot_cosmetics', cookie, { sameSite: 'lax' });
+  } catch(e) {
+    console.warn('Failed to write ctjot_cosmetics cookie.', {name: e.name, message: e.message});
+  }
+}
+
+/*
+ * Reset cosmetic options to defaults and clear cookie.
+ */
+function resetCosmeticOptionsCookie() {
+  let options = getCosmeticOptions();
+  Object.entries(options).forEach(([id, option]) => {
+    let elem = document.getElementById("id_" + id);
+    if (elem) {
+      if (option.type == 'checked') {
+        let checked = option.default;
+        if (checked) { $('#id_' + id).bootstrapToggle('on'); }
+        else { $('#id_' + id).bootstrapToggle('off'); }
+      } else {
+        elem.value = option.default;
+      }
+    } else {
+      console.warn('Undefined cosmetics element.', {id: id});
+    }
+  });
+
+  // delete cookie
+  Cookies.remove('ctjot_cosmetics');
+
+  updateGameOptions();
 }

--- a/generator/templates/generator/base.html
+++ b/generator/templates/generator/base.html
@@ -12,6 +12,7 @@
     <script src="https://cdn.jsdelivr.net/gh/gitbrent/bootstrap4-toggle@3.6.1/js/bootstrap4-toggle.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.5/dist/js.cookie.min.js"></script>
     {% block imports %}
     {% endblock %}
   </head>

--- a/generator/templates/generator/seed.html
+++ b/generator/templates/generator/seed.html
@@ -3,6 +3,7 @@
 {% block title %}Seed {{ share_id }} - {{ block.super }}{% endblock %}
 
 {% block imports %}
+    {{ cosmetics | json_script:"cosmetics-options" }}
     {% load static %}
     <script src="{% static 'generator/seed.js' %}"></script>
     <link rel="stylesheet" href="{% static 'generator/background_select.css' %}">

--- a/generator/templates/generator/seed/cosmetic_options.html
+++ b/generator/templates/generator/seed/cosmetic_options.html
@@ -1,5 +1,4 @@
-
-          <input type="button" class="btn btn-primary" id="cosmetic_options_button" value="Show Cosmetic Options" data-toggle="collapse" data-target="#cosmetic_section" aria-expanded="false" aria-controls="cosmetic_section">
+          <input type="button" class="btn btn-primary" id="cosmetic_options_button" value="Show Cosmetic Options" data-toggle="collapse" data-target="#cosmetic_section" aria-expanded="false" aria-controls="cosmetic_section" onclick="updateGameOptions()">
 
           <div class="tab-content border border-primary rounded p-2 collapse" id="cosmetic_section">
             <ul class="nav nav-tabs">
@@ -11,27 +10,27 @@
             <!-- General Cosmetic Options -->
             <div class="tab-pane fade show active" id="cosmetic_general">
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.reduce_flashes.name}}" id="{{form.reduce_flashes.id_for_label}}" data-toggle="toggle">
+                <input type="checkbox" name="{{form.reduce_flashes.name}}" id="{{form.reduce_flashes.id_for_label}}" data-toggle="toggle"{% if cosmetics.reduce_flashes.value %} checked{% endif %}>
                 <label for="{{form.reduce_flashes.id_for_label}}">Reduce Flashes</label>
               </div>
 
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.quiet_mode.name}}" id="{{form.quiet_mode.id_for_label}}" data-toggle="toggle">
+                <input type="checkbox" name="{{form.quiet_mode.name}}" id="{{form.quiet_mode.id_for_label}}" data-toggle="toggle"{% if cosmetics.quiet_mode.value %}checked{% endif %}>
                 <label for="{{form.quiet_mode.id_for_label}}">Quiet Mode - No Music</label>
               </div>
 
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.zenan_alt_battle_music.name}}" id="{{form.zenan_alt_battle_music.id_for_label}}" data-toggle="toggle">
+                <input type="checkbox" name="{{form.zenan_alt_battle_music.name}}" id="{{form.zenan_alt_battle_music.id_for_label}}" data-toggle="toggle"{% if cosmetics.zenan_alt_battle_music.value %}checked{% endif %}>
                 <label for="{{form.zenan_alt_battle_music.id_for_label}}">Zenan Alt Battle Music</label>
               </div>
 
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.death_peak_alt_music.name}}" id="{{form.death_peak_alt_music.id_for_label}}" data-toggle="toggle">
+                <input type="checkbox" name="{{form.death_peak_alt_music.name}}" id="{{form.death_peak_alt_music.id_for_label}}" data-toggle="toggle"{% if cosmetics.death_peak_alt_music.value %}checked{% endif %}>
                 <label for="{{form.death_peak_alt_music.id_for_label}}">Death Peak Alt Music</label>
               </div>
-	      
+
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.auto_run.name}}" id="{{form.auto_run.id_for_label}}" data-toggle="toggle">
+                <input type="checkbox" name="{{form.auto_run.name}}" id="{{form.auto_run.id_for_label}}" data-toggle="toggle"{% if cosmetics.auto_run.value %}checked{% endif %}>
                 <label for="{{form.auto_run.id_for_label}}">Auto-Run</label>
               </div>
 
@@ -40,57 +39,57 @@
             <!-- Menu background selection -->
             <div class="tab-pane fade show" id="cosmetic_in_game_options">
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.stereo_audio.name}}" id="{{form.stereo_audio.id_for_label}}" data-toggle="toggle" checked>
+                <input type="checkbox" name="{{form.stereo_audio.name}}" id="{{form.stereo_audio.id_for_label}}" data-toggle="toggle"{% if cosmetics.stereo_audio.value %}checked{% endif %}>
                 <label for="{{form.stereo_audio.id_for_label}}">Stereo Audio</label>
               </div>
 
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.save_menu_cursor.name}}" id="{{form.save_menu_cursor.id_for_label}}" data-toggle="toggle">
+                <input type="checkbox" name="{{form.save_menu_cursor.name}}" id="{{form.save_menu_cursor.id_for_label}}" data-toggle="toggle"{% if cosmetics.save_menu_cursor.value %}checked{% endif %}>
                 <label for="{{form.save_menu_cursor.id_for_label}}">Save Menu Cursor</label>
               </div>
 
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.save_battle_cursor.name}}" id="{{form.save_battle_cursor.id_for_label}}" data-toggle="toggle">
+                <input type="checkbox" name="{{form.save_battle_cursor.name}}" id="{{form.save_battle_cursor.id_for_label}}" data-toggle="toggle"{% if cosmetics.save_battle_cursor.value %}checked{% endif %}>
                 <label for="{{form.save_battle_cursor.id_for_label}}">Save Battle Cursor</label>
               </div>
 
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.save_skill_item_cursor.name}}" id="{{form.save_skill_item_cursor.id_for_label}}" data-toggle="toggle" checked>
+                <input type="checkbox" name="{{form.save_skill_item_cursor.name}}" id="{{form.save_skill_item_cursor.id_for_label}}" data-toggle="toggle"{% if cosmetics.save_skill_item_cursor.value %}checked{% endif %}>
                 <label for="{{form.save_skill_item_cursor.id_for_label}}">Save Skill/Item Cursor</label>
               </div>
 
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.skill_item_info.name}}" id="{{form.skill_item_info.id_for_label}}" data-toggle="toggle" checked>
+                <input type="checkbox" name="{{form.skill_item_info.name}}" id="{{form.skill_item_info.id_for_label}}" data-toggle="toggle"{% if cosmetics.skill_item_info.value %}checked{% endif %}>
                 <label for="{{form.skill_item_info.id_for_label}}">Skill/Item Info</label>
               </div>
 
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.consistent_paging.name}}" id="{{form.consistent_paging.id_for_label}}" data-toggle="toggle">
+                <input type="checkbox" name="{{form.consistent_paging.name}}" id="{{form.consistent_paging.id_for_label}}" data-toggle="toggle"{% if cosmetics.consistent_paging.value %}checked{% endif %}>
                 <label for="{{form.consistent_paging.id_for_label}}">Consistent Paging</label>
               </div>
 
               <div class="form-group">
                 <label for="{{form.battle_speed.id_for_label}}" class="form-label mr-2">Battle Speed:</label>
-                <input type="range" class="form-range" name="{{form.battle_speed.name}}" id="{{form.battle_speed.id_for_label}}" min="1" max="8" value="5" oninput="updateGameOptions()" onchange="updateGameOptions()" >
-                <input type="text" id="battle_speed_text" form="none" size="1" value="5" readonly>
+                <input type="range" class="form-range" name="{{form.battle_speed.name}}" id="{{form.battle_speed.id_for_label}}" min="1" max="8" value="{{cosmetics.battle_speed.value}}" oninput="updateGameOptions()" onchange="updateGameOptions()" >
+                <input type="text" id="battle_speed_text" form="none" size="1" value="{{cosmetics.battle_speed.value}}" readonly>
               </div>
 
               <div class="form-group">
                 <label for="{{form.battle_message_speed.id_for_label}}" class="form-label mr-2">Battle Message Speed:</label>
-                <input type="range" class="form-range" name="{{form.battle_message_speed.name}}" id="{{form.battle_message_speed.id_for_label}}" min="1" max="8" value="5" oninput="updateGameOptions()" onchange="updateGameOptions()" >
-                <input type="text" id="battle_message_speed_text" form="none" size="1" value="5" readonly>
+                <input type="range" class="form-range" name="{{form.battle_message_speed.name}}" id="{{form.battle_message_speed.id_for_label}}" min="1" max="8" value="{{cosmetics.battle_message_speed.value}}" oninput="updateGameOptions()" onchange="updateGameOptions()" >
+                <input type="text" id="battle_message_speed_text" form="none" size="1" value="{{cosmetics.battle_message_speed.value}}" readonly>
               </div>
 
               <div class="form-group">
                 <label for="{{form.battle_gauge_style.id_for_label}}" class="form-label mr-2">Battle Gauge Style:</label>
-                <input type="range" class="form-range" name="{{form.battle_gauge_style.name}}" id="{{form.battle_gauge_style.id_for_label}}" min="0" max="2" value="1" oninput="updateGameOptions()" onchange="updateGameOptions()" >
-                <input type="text" id="battle_gauge_style_text" form="none" size="1" value="1" readonly>
+                <input type="range" class="form-range" name="{{form.battle_gauge_style.name}}" id="{{form.battle_gauge_style.id_for_label}}" min="0" max="2" value="{{cosmetics.battle_gauge_style.value}}" oninput="updateGameOptions()" onchange="updateGameOptions()" >
+                <input type="text" id="battle_gauge_style_text" form="none" size="1" value="{{cosmetics.battle_gauge_style.value}}" readonly>
               </div>
 
               <div class="form-group">
                 <label for="{{form.background_selection.id_for_label}}" class="form-label mr-2">Background:</label>
-                <input type="range" class="form-range" name="{{form.background_selection.name}}" id="{{form.background_selection.id_for_label}}" min="1" max="8" value="1" oninput="updateGameOptions()" onchange="updateGameOptions()" >
-                <input type="text" id="background_selection_text" form="none" size="1" value="1" readonly>
+                <input type="range" class="form-range" name="{{form.background_selection.name}}" id="{{form.background_selection.id_for_label}}" min="1" max="8" value="{{cosmetics.background_selection.value}}" oninput="updateGameOptions()" onchange="updateGameOptions()" >
+                <input type="text" id="background_selection_text" form="none" size="1" value="{{cosmetics.background_selection.value}}" readonly>
               </div>
               <span id="background_selection_preview" class="menuBackground1"></span>
             </div>
@@ -100,38 +99,44 @@
             <div class="tab-pane fade show" id="cosmetic_names">
               <div class="form-group">
                 <label for="{{form.crono_name.id_for_label}}">Crono:
-                  <input class="form-control" name="{{form.crono_name.name}}" id="{{form.crono_name.id_for_label}}" type="text" value="Crono">
+                  <input class="form-control" name="{{form.crono_name.name}}" id="{{form.crono_name.id_for_label}}" type="text" value="{{cosmetics.crono_name.value}}">
                 </label>
 
                 <label for="{{form.marle_name.id_for_label}}">Marle:
-                  <input class="form-control" name="{{form.marle_name.name}}" id="{{form.marle_name.id_for_label}}" type="text" value="Marle">
+                  <input class="form-control" name="{{form.marle_name.name}}" id="{{form.marle_name.id_for_label}}" type="text" value="{{cosmetics.marle_name.value}}">
                 </label>
 
                 <label for="{{form.lucca_name.id_for_label}}">Lucca:
-                  <input class="form-control" name="{{form.lucca_name.name}}" id="{{form.lucca_name.id_for_label}}" type="text" value="Lucca">
+                  <input class="form-control" name="{{form.lucca_name.name}}" id="{{form.lucca_name.id_for_label}}" type="text" value="{{cosmetics.lucca_name.value}}">
                 </label>
               </div>
               <div class="form-group">
                 <label for="{{form.robo_name.id_for_label}}">Robo:
-                  <input class="form-control" name="{{form.robo_name.name}}" id="{{form.robo_name.id_for_label}}" type="text" value="Robo">
+                  <input class="form-control" name="{{form.robo_name.name}}" id="{{form.robo_name.id_for_label}}" type="text" value="{{cosmetics.robo_name.value}}">
                 </label>
 
                 <label for="{{form.frog_name.id_for_label}}">Frog:
-                  <input class="form-control" name="{{form.frog_name.name}}" id="{{form.frog_name.id_for_label}}" type="text" value="Frog">
+                  <input class="form-control" name="{{form.frog_name.name}}" id="{{form.frog_name.id_for_label}}" type="text" value="{{cosmetics.frog_name.value}}">
                 </label>
 
                 <label for="{{form.ayla_name.id_for_label}}">Ayla:
-                  <input class="form-control" name="{{form.ayla_name.name}}" id="{{form.ayla_name.id_for_label}}" type="text" value="Ayla">
+                  <input class="form-control" name="{{form.ayla_name.name}}" id="{{form.ayla_name.id_for_label}}" type="text" value="{{cosmetics.ayla_name.value}}">
                 </label>
               </div>
               <div class="form-group">
                 <label for="{{form.magus_name.id_for_label}}">Magus:
-                  <input class="form-control" name="{{form.magus_name.name}}" id="{{form.magus_name.id_for_label}}" type="text" value="Magus">
+                  <input class="form-control" name="{{form.magus_name.name}}" id="{{form.magus_name.id_for_label}}" type="text" value="{{cosmetics.magus_name.value}}">
                 </label>
 
                 <label for="{{form.epoch_name.id_for_label}}">Epoch:
-                  <input class="form-control" name="{{form.epoch_name.name}}" id="{{form.epoch_name.id_for_label}}" type="text" value="Epoch">
+                  <input class="form-control" name="{{form.epoch_name.name}}" id="{{form.epoch_name.id_for_label}}" type="text" value="{{cosmetics.epoch_name.value}}">
                 </label>
               </div>
+            </div>
+
+            <div class="form-group form-check pl-0">
+              <input type="button" class="btn btn-outline-primary btn-sm" id="save_cosmetic_options_button" value="Save Cosmetics" onclick="saveCosmeticOptionsCookie()" title="Save cosmetic options to cookie.">
+              <input type="button" class="btn btn-outline-primary btn-sm" id="load_cosmetic_options_button" value="Load Cosmetics" onclick="loadCosmeticOptionsCookie()" title="Load cosmetic options from cookie.">
+              <input type="button" class="btn btn-outline-primary btn-sm" id="reset_cosmetic_options_button" value="Reset Cosmetics" onclick="resetCosmeticOptionsCookie()" title="Reset cosmetic options to defaults and remove cookie.">
             </div>
           </div>


### PR DESCRIPTION
Adds ability to push button under Cosmetics Options to save cosmetics settings to a cookie ("ctjot_cosmetics").

When that cookie is present, when a seed is generated, values are read from the cookie and pre-populate cosmetic settings on the seed share page.

Also adds ability to explicitly re-load from cookie or reset to defaults (which also removes cookie).

No cookie is written unless user explicitly clicks "Save Cosmetics" button.

## Updates

* Adds "Save Cosmetics", "Load Cosmetics", and "Reset Cosmetics" buttons under "Show Cosmetic Options" drop-down on seed share page.
* Creates "ctjot_cosmetics" cookie when "Save Cosmetics" button is pushed, storing cosmetic settings options in base64-encoded JSON.
* Loads cosmetics values from cookie when "Load Cosmetics" button is pushed.
* Resets cosmetics values to defaults when "Reset Cosmetics" button is pushed (and removes "ctjot_cosmetics" cookie).
* When a new seed is generated, if the "ctjot_cosmetics" cookie is present, pre-populates cosmetic options with values read from cookie.

## Examples

Running development `docker-compose` setup locally (`./deploy/deploy.sh -d`).

### No cookie set

With no cookie set, seed page is pre-populated with defaults.

1. Create new seed
2. Show Cosmetics Options, it shows defaults
3. Make some changes
4. Click "Reset Cosmetics", it reloads defaults
5. Make some changes
6. Click "Save Cosmetics"
7. Make more changes
8. Click "Load Cosmetics", it loads from saved changes

![no-cookie-set](https://github.com/Anguirel86/ctjot_web_generator/assets/3493534/a4029668-c96b-4c67-a02c-beaf6e5a538a)

### Cookie set

With a cookie set, seed page is pre-populated with cosmetics options read from "ctjot_cosmetics" cookie.

1. Create another seed
2. Show Cosmetics Options, it shows values read from cookie
3. Make some changes
4. Click "Load Cosmetics", it loads from saved changes
5. Click "Reset Cosmetics", it reloads defaults (and deletes cookie)

![cookie-set](https://github.com/Anguirel86/ctjot_web_generator/assets/3493534/db471ed1-658c-4860-aaee-73bfc764d14e)

## TODO

* If this looks good, can cherry-pick commit onto `master` branch as well (separate PR)