### PR TITLE
Implement query-string-based cache-busting for static js files

### DIFF
--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -1,19 +1,28 @@
+# Development environment
+#
+# The JETSOFTIME_PATH environment variable can be set prior to running
+# docker-compose (or using deploy.sh script) to override location of
+# jetsoftime code to mount into container, e.g. for testing changes
+# using local changes to jetsoftime code in another directory.
+# By default, it will use the checked out submodule.
+---
 version: '3.8'
 
 services:
   web-generator:
-    build: 
+    build:
       context: ../
       dockerfile: deploy/Dockerfile
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - ../ct.sfc:/home/ctjot/web/ct.sfc
+      - "${JETSOFTIME_PATH:-../jetsoftime}:/home/ctjot/web/jetsoftime"
     ports:
       - 8000:8000
     env_file:
       - ./.env.dev
       - ./.env.dev.db
-  
+
   db:
     image: postgres:13.0-alpine
     volumes:

--- a/generator/apps.py
+++ b/generator/apps.py
@@ -1,6 +1,19 @@
+from hashlib import md5
+from pathlib import Path
+from typing import Dict
+
 from django.apps import AppConfig
 
 
 class GeneratorConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'generator'
+
+    # map truncated path to each static .js file to it's MD5 checksum
+    # to use as a "version" query for cache-busting
+    # so browser consistently reloads js files on changes
+    js_versions : Dict[str, str] = {
+        str(Path(*path.parts[2:])): md5(path.read_bytes()).hexdigest()
+        for path in Path('generator/static').rglob('*.js')
+    }
+

--- a/generator/templates/generator/options.html
+++ b/generator/templates/generator/options.html
@@ -2,7 +2,7 @@
 
 {% block imports %}
     {% load static %}
-    <script src="{% static 'generator/options.js' %}"></script>
+    <script src="{% static 'generator/options.js' %}?v={{ js_version }}"></script>
     <link rel="stylesheet" href="{% static 'generator/styles.css' %}">
 {% endblock %}
 

--- a/generator/templates/generator/seed.html
+++ b/generator/templates/generator/seed.html
@@ -5,7 +5,7 @@
 {% block imports %}
     {{ cosmetics | json_script:"cosmetics-options" }}
     {% load static %}
-    <script src="{% static 'generator/seed.js' %}"></script>
+    <script src="{% static 'generator/seed.js' %}?v={{ js_version }}"></script>
     <link rel="stylesheet" href="{% static 'generator/background_select.css' %}">
     {% if is_permalink %}
       <meta property="og:title" content="Seed {{ share_id }} - Chrono Trigger: Jets of Time Randomizer" />

--- a/generator/templates/tracker/tracker.html
+++ b/generator/templates/tracker/tracker.html
@@ -4,7 +4,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 
-    <script src="{% static 'tracker/logic.js' %}"></script>
+    <script src="{% static 'tracker/logic.js' %}?v={{ js_version }}"></script>
     <link rel="stylesheet" href="{% static 'tracker/trackerstyles.css' %}">
   </head>
 

--- a/generator/urls.py
+++ b/generator/urls.py
@@ -7,7 +7,7 @@ app_name = 'generator'
 
 urlpatterns = [
     path('', TemplateView.as_view(template_name="generator/index.html"), name='index'),
-    path('tracker/', TemplateView.as_view(template_name="tracker/tracker.html"), name='tracker'),
+    path('tracker/', views.TrackerView.as_view(), name='tracker'),
     path('options/', views.OptionsView.as_view(), name='options'),
     path('generate-rom/', views.GenerateView.as_view(), name='generate'),
     path('share/<str:share_id>/', views.ShareLinkView.as_view(), name='share'),

--- a/generator/views.py
+++ b/generator/views.py
@@ -1,4 +1,5 @@
 # Django libraries
+from django.apps import apps
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render, redirect
 from wsgiref.util import FileWrapper
@@ -53,7 +54,12 @@ class OptionsView(View):
     @classmethod
     def get(cls, request):
         form = GenerateForm()
-        context = {'form': form}
+
+        # use MD5 checksum of options.js contents to cache-bust on changes to file
+        app = apps.get_app_config('generator')
+        js_version = app.js_versions['generator/options.js']
+
+        context = {'form': form, 'js_version': js_version}
         return render(request, 'generator/options.html', context)
 
 
@@ -95,6 +101,10 @@ class ShareLinkView(View):
         share_info = RandomizerInterface.get_share_details(
             pickle.loads(game.configuration), pickle.loads(game.settings), game.seed_hash)
 
+        # use MD5 checksum of seed.js contents to cache-bust on changes to file
+        app = apps.get_app_config('generator')
+        js_version = app.js_versions['generator/seed.js']
+
         rom_form = RomForm()
         context = {'share_id': game.share_id,
                    'is_permalink': True,
@@ -106,6 +116,7 @@ class ShareLinkView(View):
                    ),
                    'cosmetics': get_cosmetics(request),
                    'is_race_seed': game.race_seed,
+                   'js_version': js_version,
                    'share_info': share_info.getvalue()}
 
         return render(request, 'generator/seed.html', context)
@@ -290,6 +301,21 @@ class SeedImageView(View):
             response['Content-Length'] = l
             response.write(f.getbuffer())
             return response
+
+
+class TrackerView(View):
+    """
+    Handle the tracker page for the Jets of Time web generator.
+    """
+
+    @classmethod
+    def get(cls, request):
+        # use MD5 checksum of logic.js contents to cache-bust on changes to file
+        app = apps.get_app_config('generator')
+        js_version = app.js_versions['tracker/logic.js']
+
+        context = {'js_version': js_version}
+        return render(request, 'tracker/tracker.html', context)
 
 
 def get_share_id() -> str:


### PR DESCRIPTION
This PR implements a relatively simple method of cache-busting for static js files, which will compel the browser to reload them when they change. A query string is added on to the requests to download the js scripts with a "version" string (`?v={{ js_version }}`). The version is injected from the view and is the MD5 checksum of the script file (computed once when the app starts and stuffed into AppConfig).

Without this, browsers can inconsistently use older versions. This is readily apparent when developing and making changes to `options.js` and the browser using the old, cached versions, even on a page refresh.

Limitation of this method is that it requires restarting the app to pickup those changes (but I'm guessing our production sites even are just rebuilding/restarting the docker containers for the app to pickup changes, instead of pushing live, so this should work fine there, too).

## Testing

Tested changes with `./deploy/deploy.sh -d`. Monitor docker-compose logs and saw it was correctly receiving requests with version query string with MD5 checksum. Changed `option.js` and redeployed and observed the sum change as browser requested new "version". Changes were picked up immediately in browser demonstrating cache-busting.