### PR TITLE
UX updates: toggle tabs based on features; collapse character selections

### DIFF
--- a/generator/static/generator/options.js
+++ b/generator/static/generator/options.js
@@ -3,11 +3,23 @@
  * the game options, including preset and validation functions.
  */
 
+/*
+ * Initialize some UI settings when page (re-)loaded.
+ */
+function initAll() {
+  let options = ['duplicate_characters', 'boss_rando', 'mystery_seed', 'bucket_list']
+  options.forEach((option) => toggleOptions(option));
+  restrictFlags();
+}
+$(document).ready(initAll);
 
 /*
  * Reset all form inputs to default values.
  */
 function resetAll() {
+  // direct focus back to General tab
+  $('a[href="#options-general"]').tab('show');
+
   // General options
   $('#id_enemy_difficulty').val('normal');
   $('#id_item_difficulty').val('normal');
@@ -223,20 +235,6 @@ function dcUncheckAll() {
 }
 
 /*
- * Set the visibility of the Duplicate Characters options section.
- */
-function toggleDCOptions() {
-  var dupCharsSelected = $('id_duplicate_characters').prop('checked')
-  document.getElementById('dcOptionsButton').disabled = !(dupCharsSelected);
-
-  // Hide the duplicate character options div if the duplicate characters 
-  // checkbox is unselected. 
-  if (!dupCharsSelected) {
-    $('#dup_char_options').collapse("hide");
-  }
-}
-
-/*
  * Encode the character choices into the hidden form field.
  * Each character is represented by a 2 digit hex string where the
  * bit index represents the character ID. ie:
@@ -357,6 +355,22 @@ function updateMysterySettings() {
 
   for (const id of id_list_percentage) {
     document.getElementById(id + "_text").value = document.getElementById("id_" + id).value + "%"
+  }
+}
+
+/*
+ * Set the visibility of an options section.
+ */
+function toggleOptions(option) {
+  let optionSelected = $('#id_' + option).prop('checked');
+  let optionNav = $('#id_' + option + '_nav');
+
+  if (optionSelected) {
+    optionNav.removeClass('disabled');
+    optionNav.prop('disabled', false);
+  } else {
+    optionNav.addClass('disabled');
+    optionNav.prop('disabled', true);
   }
 }
 

--- a/generator/static/generator/options.js
+++ b/generator/static/generator/options.js
@@ -59,47 +59,47 @@ function resetAll() {
   $('#id_starters_sufficient').prop('checked', false).change();
 
   $('#id_bucket_list').prop('checked', false).change();
-  
+
   // Mystery Seed options
   // game modes
-  $('#id_mystery_game_mode_standard').val(75).change()
-  $('#id_mystery_game_mode_lw').val(25).change()
-  $('#id_mystery_game_mode_loc').val(0).change()
-  $('#id_mystery_game_mode_ia').val(0).change()
+  $('#id_mystery_game_mode_standard').val(75).change();
+  $('#id_mystery_game_mode_lw').val(25).change();
+  $('#id_mystery_game_mode_loc').val(0).change();
+  $('#id_mystery_game_mode_ia').val(0).change();
   // item difficulty
-  $('#id_mystery_item_difficulty_easy').val(15).change()
-  $('#id_mystery_item_difficulty_normal').val(70).change()
-  $('#id_mystery_item_difficulty_hard').val(15).change()
+  $('#id_mystery_item_difficulty_easy').val(15).change();
+  $('#id_mystery_item_difficulty_normal').val(70).change();
+  $('#id_mystery_item_difficulty_hard').val(15).change();
   // enemy difficulty
-  $('#id_mystery_enemy_difficulty_normal').val(75).change()
-  $('#id_mystery_enemy_difficulty_hard').val(25).change()
+  $('#id_mystery_enemy_difficulty_normal').val(75).change();
+  $('#id_mystery_enemy_difficulty_hard').val(25).change();
   // tech order
-  $('#id_mystery_tech_order_normal').val(10).change()
-  $('#id_mystery_tech_order_full_random').val(80).change()
-  $('#id_mystery_tech_order_balanced_random').val(10).change()
+  $('#id_mystery_tech_order_normal').val(10).change();
+  $('#id_mystery_tech_order_full_random').val(80).change();
+  $('#id_mystery_tech_order_balanced_random').val(10).change();
   // shop prices
-  $('#id_mystery_shop_prices_normal').val(70).change()
-  $('#id_mystery_shop_prices_random').val(10).change()
-  $('#id_mystery_shop_prices_mostly_random').val(10).change()
-  $('#id_mystery_shop_prices_free').val(10).change()
+  $('#id_mystery_shop_prices_normal').val(70).change();
+  $('#id_mystery_shop_prices_random').val(10).change();
+  $('#id_mystery_shop_prices_mostly_random').val(10).change();
+  $('#id_mystery_shop_prices_free').val(10).change();
   // flag probabilities
-  $('#id_mystery_tab_treasures').val(10).change()
-  $('#id_mystery_unlock_magic').val(50).change()
-  $('#id_mystery_bucket_list').val(15).change()
-  $('#id_mystery_chronosanity').val(30).change()
-  $('#id_mystery_boss_rando').val(50).change()
-  $('#id_mystery_boss_scale').val(30).change()
-  $('#id_mystery_locked_characters').val(25).change()
-  $('#id_mystery_duplicate_characters').val(25).change()
-  $('#id_mystery_epoch_fail').val(50).change()
-  $('#id_mystery_gear_rando').val(25).change()
-  $('#id_mystery_heal_rando').val(25).change()
-  
+  $('#id_mystery_tab_treasures').val(10).change();
+  $('#id_mystery_unlock_magic').val(50).change();
+  $('#id_mystery_bucket_list').val(15).change();
+  $('#id_mystery_chronosanity').val(30).change();
+  $('#id_mystery_boss_rando').val(50).change();
+  $('#id_mystery_boss_scale').val(30).change();
+  $('#id_mystery_locked_characters').val(25).change();
+  $('#id_mystery_char_rando').val(50).change();
+  $('#id_mystery_duplicate_characters').val(25).change();
+  $('#id_mystery_epoch_fail').val(50).change();
+  $('#id_mystery_gear_rando').val(25).change();
+  $('#id_mystery_heal_rando').val(25).change();
+
   // Bucket Settings
-  $('#id_bucket_num_objs').val(5).change()
-  $('#id_bucket_num_objs_req').val(4).change()
-  updateObjectiveCount()
-  
+  $('#id_bucket_num_objs').val(5).change();
+  $('#id_bucket_num_objs_req').val(4).change();
+  updateObjectiveCount();
 }
 
 /*
@@ -136,7 +136,7 @@ function presetLostWorlds() {
   resetAll();
   $('#id_enemy_difficulty').val('normal');
   $('#id_item_difficulty').val('normal');
-  $('#id_game_mode').val('lost_worlds').change()
+  $('#id_game_mode').val('lost_worlds').change();
   $('#id_disable_glitches').prop('checked', true).change();
   $('#id_zeal').prop('checked', true).change();
   $('#id_tech_rando').val('fully_random');
@@ -160,7 +160,7 @@ function presetHard() {
  */
 function presetLegacyOfCyrus() {
   resetAll();
-  $('#id_game_mode').val('legacy_of_cyrus').change()
+  $('#id_game_mode').val('legacy_of_cyrus').change();
   $('#id_enemy_difficulty').val('normal');
   $('#id_item_difficulty').val('normal');
   $('#id_disable_glitches').prop('checked', true).change();
@@ -241,7 +241,7 @@ function toggleDCOptions() {
  * Each character is represented by a 2 digit hex string where the
  * bit index represents the character ID. ie:
  *   0x17 - The character can become:
- *      Crono, Marle, Lucca, or Frog. 
+ *      Crono, Marle, Lucca, or Frog.
  */
 function encodeDuplicateCharacterChoices() {
   var encodedString = "";
@@ -255,7 +255,7 @@ function encodeDuplicateCharacterChoices() {
     }
     
     if ((currentCharValue & 0xFF) < 0x10) {
-      // Pad the string with a zero if needed so that the 
+      // Pad the string with a zero if needed so that the
       // final string is 14 characters.
       encodedString += "0";
     }
@@ -299,10 +299,10 @@ function prepareForm() {
     return false;
   }
   encodeDuplicateCharacterChoices();
-    
+
   if (!validateLogicTweaks())
-      return false;     
-    
+      return false;
+
   if (!validateAndUpdateObjectives()){return false;}
   return true;
 }
@@ -370,17 +370,17 @@ function updateObjectiveCount(adjustingRequired = false){
 
     numObjs = document.getElementById("id_bucket_num_objs").value
     reqObjs = document.getElementById("id_bucket_num_objs_req").value
-    
+
     if (reqObjs > numObjs){
         if (adjustingRequired) {numObjs = reqObjs}
         else {reqObjs = numObjs}
     }
-    
+
     document.getElementById("id_bucket_num_objs").value = numObjs
     document.getElementById("numObjectivesDisp").value = numObjs
     document.getElementById("id_bucket_num_objs_req").value = reqObjs
     document.getElementById("numObjectivesRequiredDisp").value = reqObjs
-    
+
     // Now enable/disable the objective entries according to numObjs
     for(var i=0; i<8; i++){
         var isDisabled = true
@@ -525,14 +525,14 @@ const allowedQuestTags = [
 
 /*
  * Helper function to parse a quest objective.
- * param questParts, Array: An objective (e.g. 'Quest_ZenanBridge') has been cleaned and turned into 
+ * param questParts, Array: An objective (e.g. 'Quest_ZenanBridge') has been cleaned and turned into
  * the array ['quest', 'zenanbridge'] which is passed in as questParts.
  */
 function validateQuestObjective(questParts){
 
     if (questParts.length != 2){
         return false
-    }       
+    }
     if (!allowedQuestTags.includes(questParts[1])){
         return false
     }
@@ -542,8 +542,8 @@ function validateQuestObjective(questParts){
 
 /*
  * Helper function to parse a boss objective.
- * param bossParts, Array: An objective (e.g. 'Boss_MotherBrain') has been 
- * cleaned and turned into the array ['boss', 'motherbrain'] which is passed 
+ * param bossParts, Array: An objective (e.g. 'Boss_MotherBrain') has been
+ * cleaned and turned into the array ['boss', 'motherbrain'] which is passed
  * in as bossParts.
  */
 const allowedBossNames = [
@@ -575,13 +575,13 @@ const allowedRecruitNames = [
 
 /*
  * Helper function to parse a recruit objective.
- * param recruitParts, Array: An objective (e.g. 'Recruit_Crono') has been 
- * cleaned and split into an array (['recruit', 'crono']) which is passed 
+ * param recruitParts, Array: An objective (e.g. 'Recruit_Crono') has been
+ * cleaned and split into an array (['recruit', 'crono']) which is passed
  * in as recruitParts.
  */
  function validateRecruitObjective(recruitParts){
     if (recruitParts.length != 2){return false}
- 
+
     return allowedRecruitNames.includes(recruitParts[1])
  }
 
@@ -596,14 +596,14 @@ function isInteger(string){
 
 /*
  * Helper function to parse a recruit objective.
- * param collectParts, Array: An objective (e.g. 'Collect_5_Fragments_5') has 
- * been cleaned and split into an array (['collect', '5', 'fragments', '5']) 
+ * param collectParts, Array: An objective (e.g. 'Collect_5_Fragments_5') has
+ * been cleaned and split into an array (['collect', '5', 'fragments', '5'])
  * which is passed in as recruitParts.
  */
 function validateCollectObjective(collectParts){
     if (collectParts.length < 2){
         return false
-    }   
+    }
     collectType = collectParts[2]
     if (collectType == 'rocks'){
         if (collectParts.length != 3){return false}
@@ -611,10 +611,10 @@ function validateCollectObjective(collectParts){
         if (!Number.isInteger(numRocks) || numRocks < 1){return false}
     } else if (collectType == 'fragments'){
         if (collectParts.length != 4){return false}
-        
+
         fragsNeeded = Number(collectParts[1])
         extraFrags = Number(collectParts[3])
-        
+
         if (!Number.isInteger(fragsNeeded) || fragsNeeded < 0){return false}
         if (!Number.isInteger(extraFrags) || extraFrags < 0){return false}
     } else {
@@ -635,15 +635,15 @@ function validateObjective(objective){
             return {isValid: true, result: objectiveDict[key]}
         }
     }
-   
+
     // Otherwise, parse the objective
     cleanedObjective = objective.replace(/\s/g,'')
-    
+
     if (cleanedObjective == ''){
         // Do something to display an error on the page for an empty objective string
         return {isValid: false, result: "Empty objective string."}
     }
-    
+
     objectiveParts = cleanedObjective.split(',')
     for (var i = 0; i < objectiveParts.length; i++){
         objectivePart = objectiveParts[i]
@@ -664,10 +664,10 @@ function validateObjective(objective){
             // Overwrite objectivePart with just the objective, not the weight
             objectivePart = weightSplit[1]
         }
-        
+
         splitObjective = objectivePart.split('_')
         objectiveType = splitObjective[0]
-        
+
         if (objectiveType == 'quest'){
             ret = validateQuestObjective(splitObjective)
         } else if (objectiveType == 'boss'){
@@ -687,7 +687,7 @@ function validateObjective(objective){
             }
         }
     }
-    
+
     return {isValid: true, result: cleanedObjective}
 }
 
@@ -708,7 +708,7 @@ function validateAndUpdateObjectives(){
         const parse = validateObjective(objective)
         const isValid = parse.isValid
         const result = parse.result
-        
+
         if (isValid){
             const formElementId = 'id_bucket_objective'+(i+1)
             document.getElementById(formElementId).value = result
@@ -722,13 +722,13 @@ function validateAndUpdateObjectives(){
             $('a[href="#options-bucket"]').tab('show');
             retFalse = true
         }
-            
+
     }
 
     if (retFalse){
         return false
     }
-    
+
     for(var i=Number(numObjs); i<8; i++){
         formElementId = 'id_bucket_objective'+(i+1)
         document.getElementById(formElementId).value = 'None'
@@ -752,7 +752,7 @@ function validateLogicTweaks(){
 
         const isChecked = document.getElementById(id).checked
         if (isChecked){numKIs++}
-            
+
     }
 
     var numSpots = 0
@@ -774,7 +774,7 @@ function validateLogicTweaks(){
 
     document.getElementById("logicTweakError").innerHTML = ""
     return true
-    
+
 }
 
 const forceOff = {
@@ -810,10 +810,10 @@ const totalForceList = [
 function restrictFlags(){
     var mode = document.getElementById("id_game_mode").value
     var disableList = forceOff[mode]
-    
+
     for(var i=0; i<totalForceList.length; i++){
         flag = totalForceList[i]
-        
+
         if(disableList.includes(flag)){
             $("#id_"+flag).parent().addClass('btn-light off disabled')
             $("#id_"+flag).parent().removeClass('btn-primary')

--- a/generator/static/generator/options.js
+++ b/generator/static/generator/options.js
@@ -7,7 +7,7 @@
  * Initialize some UI settings when page (re-)loaded.
  */
 function initAll() {
-  let options = ['duplicate_characters', 'boss_rando', 'mystery_seed', 'bucket_list']
+  let options = ['duplicate_characters', 'boss_rando', 'mystery_seed', 'bucket_list'];
   options.forEach((option) => toggleOptions(option));
   restrictFlags();
 }
@@ -112,6 +112,8 @@ function resetAll() {
   $('#id_bucket_num_objs').val(5).change();
   $('#id_bucket_num_objs_req').val(4).change();
   updateObjectiveCount();
+
+  initAll();
 }
 
 /*

--- a/generator/templates/generator/options.html
+++ b/generator/templates/generator/options.html
@@ -30,12 +30,12 @@
         <ul class="nav nav-tabs">
           <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#options-general">General</a></li>
           <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#options-tabs">Tabs</a></li>
-          <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#options-dc">Duplicate Chars</a></li>
-          <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#options-ro">Boss Rando</a></li>
+          <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#options-dc" id="id_duplicate_characters_nav">Duplicate Chars</a></li>
+          <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#options-ro" id="id_boss_rando_nav">Boss Rando</a></li>
           <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#options-qol">Quality of Life</a></li>
           <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#options-extra">Extra</a></li>
-          <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#options-mystery">Mystery</a></li>
-          <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#options-bucket">Bucket</a></li>
+          <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#options-mystery" id="id_mystery_seed_nav">Mystery</a></li>
+          <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#options-bucket" id="id_bucket_list_nav">Bucket</a></li>
         </ul>
 
         <div class="tab-content">

--- a/generator/templates/generator/options/dup_char_tab.html
+++ b/generator/templates/generator/options/dup_char_tab.html
@@ -1,42 +1,48 @@
 
-            <div class="border border-primary rounded p-2 mb-3">
-              <input type="hidden" name="{{form.duplicate_char_assignments.name}}" id="{{form.duplicate_char_assignments.id_for_label}}">
-              <p>Select which characters can turn into which other characters:</p>
-              <div id="character_selection_error" class="errorText"></div>
-              <table>
-                <tr>
-                  <th></th>
-                  <th>Crono</th>
-                  <th>Marle</th>
-                  <th>Lucca</th>
-                  <th>Robo</th>
-                  <th>Frog</th>
-                  <th>Ayla</th>
-                  <th>Magus</th>
-                </tr>
-
-                {% with 'Crono Marle Lucca Robo Frog Ayla Magus' as chars %}
-                  {% for character in chars.split %}
-                    <tr>
-                      <td>{{character}} can be:</td>
-                      <td><input type="checkbox" id="dc_{{character}}0" form="none" checked /></td>
-                      <td><input type="checkbox" id="dc_{{character}}1" form="none" checked /></td>
-                      <td><input type="checkbox" id="dc_{{character}}2" form="none" checked /></td>
-                      <td><input type="checkbox" id="dc_{{character}}3" form="none" checked /></td>
-                      <td><input type="checkbox" id="dc_{{character}}4" form="none" checked /></td>
-                      <td><input type="checkbox" id="dc_{{character}}5" form="none" checked /></td>
-                      <td><input type="checkbox" id="dc_{{character}}6" form="none" checked /></td>
-                    </tr>
-                  {% endfor %}
-                {% endwith %}
-              </table>
-              <div class="pt-2">
-                <input class="btn btn-primary" type="button" form="none" value="Check All" onclick="dcCheckAll()">
-                <input class="btn btn-primary" type="button" form="none" value="Uncheck All" onclick="dcUncheckAll()">
-              </div>
+            <div class="tab-content border border-primary rounded p-2 mb-3">
 
               <div class="form-group form-check pt-3 pl-0">
                 <input type="checkbox" name="{{form.duplicate_duals.name}}" id="{{form.duplicate_duals.id_for_label}}" data-toggle="toggle" />
                 <label for="{{form.duplicate_duals.id_for_label}}">Duplicate Dual Techs</label>
               </div>
+
+              <input type="button" class="btn btn-outline-primary" id="duplicate_char_assignments_button" value="Limit Character Assignments" data-toggle="collapse" data-target="#character_selection_matrix" aria-expanded="false" aria-controls="character_selection_matrix">
+
+              <div class="border border-secondary rounded p-2 mb-3 mt-3 collapse" id="character_selection_matrix">
+                <input type="hidden" name="{{form.duplicate_char_assignments.name}}" id="{{form.duplicate_char_assignments.id_for_label}}">
+                <p>Select which character identities can be assigned which character models:</p>
+                <div id="character_selection_error" class="errorText"></div>
+                <table>
+                  <tr>
+                    <th></th>
+                    <th>Crono</th>
+                    <th>Marle</th>
+                    <th>Lucca</th>
+                    <th>Robo</th>
+                    <th>Frog</th>
+                    <th>Ayla</th>
+                    <th>Magus</th>
+                  </tr>
+  
+                  {% with 'Crono Marle Lucca Robo Frog Ayla Magus' as chars %}
+                    {% for character in chars.split %}
+                      <tr>
+                        <td>{{character}} can be:</td>
+                        <td><input type="checkbox" id="dc_{{character}}0" form="none" checked /></td>
+                        <td><input type="checkbox" id="dc_{{character}}1" form="none" checked /></td>
+                        <td><input type="checkbox" id="dc_{{character}}2" form="none" checked /></td>
+                        <td><input type="checkbox" id="dc_{{character}}3" form="none" checked /></td>
+                        <td><input type="checkbox" id="dc_{{character}}4" form="none" checked /></td>
+                        <td><input type="checkbox" id="dc_{{character}}5" form="none" checked /></td>
+                        <td><input type="checkbox" id="dc_{{character}}6" form="none" checked /></td>
+                      </tr>
+                   {% endfor %}
+                {% endwith %}
+                </table>
+                <div class="pt-2">
+                  <input class="btn btn-outline-primary btn-sm" type="button" form="none" value="Check All" onclick="dcCheckAll()">
+                  <input class="btn btn-outline-primary btn-sm" type="button" form="none" value="Uncheck All" onclick="dcUncheckAll()">
+                </div>
+              </div>
+
             </div>

--- a/generator/templates/generator/options/extra_tab.html
+++ b/generator/templates/generator/options/extra_tab.html
@@ -13,7 +13,7 @@
                 <label for="{{form.starters_sufficient.id_for_label}}">Starters Sufficient</label>
               </div>
               <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.bucket_list.name}}" id="{{form.bucket_list.id_for_label}}"  data-toggle="toggle">
+                <input type="checkbox" name="{{form.bucket_list.name}}" id="{{form.bucket_list.id_for_label}}" data-toggle="toggle" onchange="toggleOptions('bucket_list')">
                 <label for="{{form.bucket_list.id_for_label}}">Bucket List</label>
               </div>
 	      <div>

--- a/generator/templates/generator/options/general_tab.html
+++ b/generator/templates/generator/options/general_tab.html
@@ -55,7 +55,7 @@
                   </div>
 
                   <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.mystery_seed.name}}" id="{{form.mystery_seed.id_for_label}}"  data-toggle="toggle">
+                    <input type="checkbox" name="{{form.mystery_seed.name}}" id="{{form.mystery_seed.id_for_label}}" data-toggle="toggle" onchange="toggleOptions('mystery_seed')">
                     <label for="{{form.mystery_seed.id_for_label}}">Mystery Seed</label>
                   </div>
                 </div>
@@ -72,7 +72,7 @@
                   </div>
 
                   <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.boss_rando.name}}" id="{{form.boss_rando.id_for_label}}" data-toggle="toggle">
+                    <input type="checkbox" name="{{form.boss_rando.name}}" id="{{form.boss_rando.id_for_label}}" data-toggle="toggle" onchange="toggleOptions('boss_rando')">
                     <label for="{{form.boss_rando.id_for_label}}">Randomize Bosses</label>
                   </div>
 
@@ -92,7 +92,7 @@
                   </div>
 
                   <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.duplicate_characters.name}}" id="{{form.duplicate_characters.id_for_label}}"  data-toggle="toggle">
+                    <input type="checkbox" name="{{form.duplicate_characters.name}}" id="{{form.duplicate_characters.id_for_label}}" data-toggle="toggle" onchange="toggleOptions('duplicate_characters')">
                     <label for="{{form.duplicate_characters.id_for_label}}">Duplicate Characters</label>
                   </div>
 

--- a/generator/templates/generator/options/mystery_tab.html
+++ b/generator/templates/generator/options/mystery_tab.html
@@ -151,19 +151,19 @@
               </div>
 
               <div class="form-group">
-                <label for="{{form.mystery_duplicate_characters.id_for_label}}" class="form-label mr-2">Epoch Fail:</label>
+                <label for="{{form.mystery_epoch_fail.id_for_label}}" class="form-label mr-2">Epoch Fail:</label>
                 <input type="range" class="form-range" name="{{form.mystery_epoch_fail.name}}" id="{{form.mystery_epoch_fail.id_for_label}}" min="0" max="100" value="50" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
                 <input type="text" id="mystery_epoch_fail_text" form="none" size="2" value="50%" readonly>
               </div>
 
               <div class="form-group">
-                <label for="{{form.mystery_duplicate_characters.id_for_label}}" class="form-label mr-2">Gear Rando:</label>
+                <label for="{{form.mystery_gear_rando.id_for_label}}" class="form-label mr-2">Gear Rando:</label>
                 <input type="range" class="form-range" name="{{form.mystery_gear_rando.name}}" id="{{form.mystery_gear_rando.id_for_label}}" min="0" max="100" value="25" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
                 <input type="text" id="mystery_gear_rando_text" form="none" size="2" value="25%" readonly>
               </div>
 
               <div class="form-group">
-                <label for="{{form.mystery_duplicate_characters.id_for_label}}" class="form-label mr-2">Heal Rando:</label>
+                <label for="{{form.mystery_heal_rando.id_for_label}}" class="form-label mr-2">Heal Rando:</label>
                 <input type="range" class="form-range" name="{{form.mystery_heal_rando.name}}" id="{{form.mystery_heal_rando.id_for_label}}" min="0" max="100" value="25" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
                 <input type="text" id="mystery_heal_rando_text" form="none" size="2" value="25%" readonly>
               </div>


### PR DESCRIPTION
This PR introduces a couple of user experience changes, with the intent of making the web generator hide irrelevant or complex items by default (so power users can still use, but new players may be less overwhelmed).

It is intended to make it clear that certain tabs are only relevant when a given feature is enabled (e.g. the "Mystery" tab is grayed out/disabled unless "Mystery Seed" is enabled) to hopefully avoid some possible confusion.

## Updates

* Bugfix: fixed mystery options for Epoch Fail, Gear Rando, Healing Rando
* Minor: whitespace cleanup, consistent semicolon usage in `options.js`
* UX: disable irrelevant tabs based on features selected (e.g. gray out and disable "Boss Rando" tab unless "Randomize Bosses" gets enabled)
* UX: collapse character assignments matrix on Duplicate Characters tab by default, click "Limit Character Assignments" to show

## Testing

Tested locally with `./deploy/deploy.sh -d` (using default submodule for `jetsoftime`).

### Disabling Irrelevant Tabs

1. By default, Duplicate Chars, Boss Rando, Mystery, and Bucket are grayed out and disabled (clicking on them doesn't navigate to tab)
2. Enabling the features on General tab (or "Bucket List" on Extras tab) makes associated tab enabled
3. Using "Reset All" forces user to General tab and grays out/disables irrelevant tabs (since features reset)

[irrelevant-tabs.webm](https://github.com/Anguirel86/ctjot_web_generator/assets/3493534/8def4d20-cb1b-484a-b5ad-a426262da2b6)

### Character Assignments

1. With Duplicate Characters enabled, navigate to Duplicate Chars tab
2. Click "Limit Character Assignments" and the matrix drops down
3. Unchecking all and hitting "Generate Seed" sends user to Duplicate Chars tab and displays error message as expected

[dupe-chars-collapse.webm](https://github.com/Anguirel86/ctjot_web_generator/assets/3493534/79d438d2-886c-490d-bb2a-0db3115f6ce2)
