### PR TITLE
Add "Spheres" section to web spoiler

### DIFF
--- a/generator/randomizerinterface.py
+++ b/generator/randomizerinterface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import os.path
 import random
+import re
 import sys
 import datetime
 
@@ -17,6 +18,7 @@ sys.path.append(os.path.join(conf.BASE_DIR, 'jetsoftime', 'sourcefiles'))
 # Randomizer types
 import ctenums
 import bossrandotypes as rotypes
+import logicwriters as logicwriter
 import randoconfig
 import randomizer
 import randosettings as rset
@@ -501,7 +503,8 @@ class RandomizerInterface:
             'characters': [],
             'key_items': [],
             'bosses': [],
-            'objectives': []
+            'objectives': [],
+            'spheres': []
         }
 
         if rset.GameFlags.BUCKET_LIST in settings.gameflags:
@@ -539,6 +542,12 @@ class RandomizerInterface:
             else:
                 boss_str = str(config.boss_assign_dict[location])
             spoiler_log['bosses'].append({'location': str(location), 'boss': boss_str})
+
+        # Sphere data
+        spheres = logicwriter.get_proof_string_from_settings_config(settings, config)
+        rgx = re.compile(r'((?P<sphere>GO|(\d?)):\s*)?(?P<desc>.+)')
+        for line in spheres.splitlines():
+            spoiler_log['spheres'].append(rgx.search(line).groupdict())
 
         return spoiler_log
     # End get_web_spoiler_log

--- a/generator/templates/generator/seed/spoiler_log_section.html
+++ b/generator/templates/generator/seed/spoiler_log_section.html
@@ -13,6 +13,7 @@
             {% if spoiler_log.objectives %}
             <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#spoiler_objectives">Objectives</a></li>
             {% endif %}
+            <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#spoiler_spheres">Spheres</a></li>
           </ul>
 
           <!-- Key Items tab -->
@@ -76,4 +77,21 @@
               {% endfor %}
             </table>
           </div>
+
+          <!-- Spheres tab -->
+          <div class="tab-pane fade show" id="spoiler_spheres">
+            <table class="table" id="sphere_table">
+              <tr>
+                <th style="width:20%; text-align:center;">Sphere</th>
+                <th>Description</th>
+              </tr>
+              {% for entry in spoiler_log.spheres %}
+                <tr>
+                  <td style="text-align:center;">{% if entry.sphere %}{{entry.sphere}}{% endif %}</td>
+                  <td>{{entry.desc}}</td>
+                </tr>
+              {% endfor %}
+            </table>
+          </div>
+
         </div> <!-- End spoiler log div -->


### PR DESCRIPTION
Minor improvement, making it easy to browse the spheres from spoilers in the web UI.

This is particularly helpful in debugging randomizer changes or debugging (e.g. was helpful for https://github.com/Pseudoarc/jetsoftime/pull/21).

## Updates

* Updates web spoiler section to include "Spheres" section
* Reads spheres data from `logicfactory` randomizer code (like how the generated txt spoiler does)

## Testing

* [Deploy and Test Integration](https://github.com/coffeemancy/ctjot_web_generator/actions/runs/6014486839)
* [Regex](https://pythex.org/?regex=((%3FP%3Csphere%3EGO%7C(%5Cd%3F))%3A%5Cs*)%3F(%3FP%3Cdesc%3E.%2B)&test_string=0%3A%20Recruit%20Crono%20from%20Starter%202%0A0%3A%20Recruit%20Marle%20from%20Cathedral%0A0%3A%20Recruit%20Ayla%20from%20Castle%0A0%3A%20Recruit%20Magus%20from%20Starter%201%0A0%3A%20Obtain%20Masamune%202%20from%20Zenan%20Bridge%20Key%0A0%3A%20Obtain%20Pendant%20from%20Snail%20Stop%20Key%0A0%3A%20Obtain%20Gate%20Key%20from%20Lazy%20Carpenter%0A0%3A%20Obtain%20Bent%20Hilt%20from%20Taban%20Key%0A0%3A%20Obtain%20Prismshard%20from%20Denadoro%20Mts%20Key%0A1%3A%20Recruit%20Lucca%20from%20Proto%20Dome%0A1%3A%20Recruit%20Robo%20from%20Dactyl%20Nest%0A1%3A%20Obtain%20Hero%20Medal%20from%20Reptite%20Lair%20Key%0A1%3A%20Obtain%20Bent%20Sword%20from%20Mt%20Woe%20Key%0A1%3A%20Obtain%20Jerky%20from%20Kings%20Trial%20Key%0A1%3A%20Obtain%20Ruby%20Knife%20from%20Arris%20Dome%20Doan%20Key%0A1%3A%20Obtain%20C%20Trigger%20from%20Sun%20Palace%20Key%0A1%3A%20Obtain%20Dreamstone%20from%20Geno%20Dome%20Key%0AGO%3A%20Tyrano%20Lair%0A2%3A%20Recruit%20Frog%20from%20Frogs%20Burrow%0A2%3A%20Obtain%20Moon%20Stone%20from%20Frogs%20Burrow%20Left%0A2%3A%20Obtain%20Clone%20from%20Fiona%20Key%0AGO%3A%20Black%20Omen%0AGO%3A%20Magus%27s%20Castle%0A3%3A%20Obtain%20Tomas%20Pop%20from%20Melchior%20Key%0A4%3A%20Obtain%20Roboribbon%20from%20Giants%20Claw%20Key&ignorecase=0&multiline=0&dotall=0&verbose=0)

Used `./deploy/deploy.sh -d` locally and verified that spoilers work, including new "Spheres" section:

[web-spoiler-spheres.webm](https://github.com/Anguirel86/ctjot_web_generator/assets/3493534/b30d3434-de26-4844-8005-062610eb6d35)

(Generated seed with "Epoch Fail" so can see the "Unlock Flight" part in spoilers.)

### Mystery Seeds

I also generated about a dozen mystery seeds without issue, and checked the spheres vs key items on a handful matched up, and they matched the downloaded spoiler log.