### PR TITLE
Rework presets, add descriptions to them, fixup presets to set boss rando options

### DIFF
--- a/generator/static/generator/options.js
+++ b/generator/static/generator/options.js
@@ -226,8 +226,14 @@ function applyPreset(preset) {
 
   rcCheckAll();
 
+  const roSetting = ((key) => {
+    if(!preset.settings.boss_rando_settings) { return false; }
+    return preset.settings.boss_rando_settings[key] || false;
+  });
+
   // Boss Rando options
-  $('#id_legacy_boss_placement').prop('checked', false).change();
+  $('#id_legacy_boss_placement').prop('checked', roSetting("legacy_boss_placement")).change();
+  $('#id_boss_spot_hp').prop('checked', roSetting("boss_spot_hp")).change();
 
   // Mystery Seed options
   const mysterySetting = ((field, key) => {
@@ -285,8 +291,12 @@ function presetRace() {
           "GameFlags.FIX_GLITCH",
           "GameFlags.ZEAL_END",
           "GameFlags.FAST_PENDANT",
-          "GameFlags.FAST_TABS"
-        ]
+          "GameFlags.BOSS_RANDO",
+          "GameFlags.FAST_TABS",
+        ],
+	"boss_rando_settings": {
+	  "boss_spot_hp": true,
+	},
       }
     }
   );
@@ -309,9 +319,23 @@ function presetNewPlayer() {
           "GameFlags.ZEAL_END",
           "GameFlags.FAST_PENDANT",
           "GameFlags.UNLOCKED_MAGIC",
+          "GameFlags.BOSS_RANDO",
           "GameFlags.VISIBLE_HEALTH",
-          "GameFlags.FAST_TABS"
-        ]
+          "GameFlags.FAST_TABS",
+          "GameFlags.BOSS_SIGHTSCOPE",
+          "GameFlags.FREE_MENU_GLITCH",
+        ],
+	"boss_rando_settings": {
+	  "boss_spot_hp": true,
+	},
+	"tab_settings": {
+	  "power_tab_min": 2,
+	  "power_tab_max": 4,
+	  "magic_tab_min": 2,
+	  "magic_tab_max": 3,
+	  "speed_tab_min": 1,
+	  "speed_tab_max": 1,
+	}
       }
     }
   );
@@ -347,16 +371,22 @@ function presetHard() {
     {
       "settings": {
         "game_mode": "Standard",
-        "enemy_difficulty": "Hard",
+        "enemy_difficulty": "Normal",
         "item_difficulty": "Hard",
-        "techorder": "Balanced random",
+        "techorder": "Full random",
         "shopprices": "Normal",
         "gameflags": [
           "GameFlags.FIX_GLITCH",
-          "GameFlags.BOSS_SCALE",
-          "GameFlags.LOCKED_CHARS",
-          "GameFlags.FAST_TABS"
-        ]
+          "GameFlags.ZEAL_END",
+          "GameFlags.FAST_PENDANT",
+          "GameFlags.BOSS_RANDO",
+          "GameFlags.FAST_TABS",
+          "GameFlags.GEAR_RANDO",
+          "GameFlags.HEALING_ITEM_RANDO",
+        ],
+	"boss_rando_settings": {
+	  "boss_spot_hp": true,
+	},
       }
     }
   );
@@ -380,7 +410,10 @@ function presetLegacyOfCyrus() {
           "GameFlags.UNLOCKED_MAGIC",
           "GameFlags.FAST_TABS",
           "GameFlags.GEAR_RANDO"
-        ]
+        ],
+	"boss_rando_settings": {
+	  "boss_spot_hp": true,
+	},
       }
     }
   );

--- a/generator/templates/generator/options/presets.html
+++ b/generator/templates/generator/options/presets.html
@@ -1,8 +1,51 @@
-      <div class="border border-primary rounded p-2">
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="resetAll()">Reset All</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetRace()">Race</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetNewPlayer()">New Player</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetLostWorlds()">Lost Worlds</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetHard()">Hard</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetLegacyOfCyrus()">Legacy of Cyrus</button>
+      <div class="row no-gutters border border-primary rounded p-2">
+	<div class="col-1"></div>
+	<div class="border col-2">
+        <button class="btn btn-primary btn-block my-1" type="button" onclick="presetNewPlayer()">Gato Cup</button>
+	<p class="px-1">This flagset is designed for new players.</p>
+	<ul class="pl-4 pr-1">
+	  <li>Goal: Defeat Lavos or Zeal</li>
+	  <li>Easy item difficulty</li>
+	  <li>Magic is unlocked</li>
+	  <li>Free menu glitch</li>
+	  <li>Improved tabs</li>
+	</ul>
+	</div>
+	<div class="border col-2">
+        <button class="btn btn-primary btn-block my-1" type="button" onclick="presetRace()">Millennial Prix</button>
+	<p class="px-1">League standard race flags.</p>
+	<ul class="pl-4 pr-1">
+	  <li>Goal: Defeat Lavos or Zeal</li>
+	  <li>Normal item difficulty</li>
+	  <li>Magic is locked</li>
+	</ul>
+	</div>
+	<div class="border col-2">
+        <button class="btn btn-primary btn-block my-1" type="button" onclick="presetHard()">Catalack Top 8</button>
+	<p class="px-1">Tournament "Top 8" flags.</p>
+	<ul class="pl-4 pr-1">
+	  <li>Goal: Defeat Lavos or Zeal</li>
+	  <li>Hard item difficulty</li>
+	  <li>Gear and Healing Items randomized</li>
+	  <li>Magic is locked</li>
+	</ul>
+	</div>
+	<div class="border col-2">
+        <button class="btn btn-primary btn-block my-1" type="button" onclick="presetLostWorlds()">Lost Worlds</button>
+	<p class="px-1">A special game mode in which 1000AD and 600AD are not available.</p>
+	<ul class="pl-4 pr-1">
+	  <li>Goal: Defeat Lavos or Zeal</li>
+	  <li>Magic is unlocked</li>
+	</ul>
+	</div>
+	<div class="border col-2">
+        <button class="btn btn-primary btn-block my-1" type="button" onclick="presetLegacyOfCyrus()">Legacy of Cyrus</button>
+	<p class="px-1">A special game mode celebrating Frog, Magus, and Cyrus.</p>
+	<ul class="pl-4 pr-1">
+	  <li>Goal: Defeat Ozzie in Ozzie's Fort</li>
+	  <li>Frog &amp; Magus must be recruited</li>
+	  <li>Magic is unlocked</li>
+	</ul>
+	</div>
       </div>
+      <button class="btn btn-primary btn-block my-1" type="button" onclick="resetAll()">Reset All</button>

--- a/generator/templates/generator/options/presets.html
+++ b/generator/templates/generator/options/presets.html
@@ -1,7 +1,7 @@
       <div class="row no-gutters border border-primary rounded p-2">
 	<div class="col-1"></div>
 	<div class="border col-2">
-        <button class="btn btn-primary btn-block my-1" type="button" onclick="presetNewPlayer()">Gato Cup</button>
+        <button class="btn btn-danger btn-block my-1" type="button" onclick="presetNewPlayer()">Gato Cup</button>
 	<p class="px-1">This flagset is designed for new players.</p>
 	<ul class="pl-4 pr-1">
 	  <li>Goal: Defeat Lavos or Zeal</li>
@@ -12,7 +12,7 @@
 	</ul>
 	</div>
 	<div class="border col-2">
-        <button class="btn btn-primary btn-block my-1" type="button" onclick="presetRace()">Millennial Prix</button>
+        <button class="btn btn-success btn-block my-1" type="button" onclick="presetRace()">Millennial Prix</button>
 	<p class="px-1">League standard race flags.</p>
 	<ul class="pl-4 pr-1">
 	  <li>Goal: Defeat Lavos or Zeal</li>
@@ -21,7 +21,7 @@
 	</ul>
 	</div>
 	<div class="border col-2">
-        <button class="btn btn-primary btn-block my-1" type="button" onclick="presetHard()">Catalack Top 8</button>
+        <button class="btn btn-warning btn-block my-1" type="button" onclick="presetHard()">Catalack Top 8</button>
 	<p class="px-1">Tournament "Top 8" flags.</p>
 	<ul class="pl-4 pr-1">
 	  <li>Goal: Defeat Lavos or Zeal</li>
@@ -31,7 +31,7 @@
 	</ul>
 	</div>
 	<div class="border col-2">
-        <button class="btn btn-primary btn-block my-1" type="button" onclick="presetLostWorlds()">Lost Worlds</button>
+        <button class="btn btn-outline-dark btn-block my-1" type="button" onclick="presetLostWorlds()">Lost Worlds</button>
 	<p class="px-1">A special game mode in which 1000AD and 600AD are not available.</p>
 	<ul class="pl-4 pr-1">
 	  <li>Goal: Defeat Lavos or Zeal</li>
@@ -39,7 +39,7 @@
 	</ul>
 	</div>
 	<div class="border col-2">
-        <button class="btn btn-primary btn-block my-1" type="button" onclick="presetLegacyOfCyrus()">Legacy of Cyrus</button>
+        <button class="btn btn-outline-success btn-block my-1" type="button" onclick="presetLegacyOfCyrus()">Legacy of Cyrus</button>
 	<p class="px-1">A special game mode celebrating Frog, Magus, and Cyrus.</p>
 	<ul class="pl-4 pr-1">
 	  <li>Goal: Defeat Ozzie in Ozzie's Fort</li>


### PR DESCRIPTION
With the guidance of @lordbatsy

This sets the new player/race/hard presets to correspond to Gato Cup, Millennial Prix (early weeks), and Catalack Cup (top 8) flags, respectively. It also puts them in that order, with LW/LoC after them in the row, and adds descriptions to each of the presets. More could be done here, but this is the starting point/feedback point at least!

How this looks on my system (didn't check what if anything we're doing with fonts or whatever, so could vary)

![image](https://github.com/user-attachments/assets/5501ccea-2440-4376-bd0a-9ba94f6bbe3a)
